### PR TITLE
Implemented property 'visibleScrollbar'

### DIFF
--- a/lib/src/body.dart
+++ b/lib/src/body.dart
@@ -8,10 +8,12 @@ import 'data.dart';
 class ExpandableTableBody extends StatefulWidget {
   final ScrollController scrollController;
   final List<ExpandableTableRow> rows;
+  final bool visibleScrollbar;
 
   ExpandableTableBody({
     required this.scrollController,
     required this.rows,
+    required this.visibleScrollbar,
   });
 
   @override
@@ -149,11 +151,21 @@ class _ExpandableTableBodyState extends State<ExpandableTableBody>
             curve: ExpandableTableData.of(context).scrollShadowCurve,
             duration: ExpandableTableData.of(context).scrollShadowDuration,
             controller: _firstColumnController,
-            child: ListView(
-              controller: _firstColumnController,
-              physics: ClampingScrollPhysics(),
-              children: firstColumn,
-            ),
+            child: ExpandableTableData.of(context).visibleScrollbar
+                ? Scrollbar(
+                    child: ListView(
+                      controller: _firstColumnController,
+                      physics: ClampingScrollPhysics(),
+                      children: firstColumn,
+                    ),
+                    isAlwaysShown: true,
+                    controller: _firstColumnController,
+                  )
+                : ListView(
+                    controller: _firstColumnController,
+                    physics: ClampingScrollPhysics(),
+                    children: firstColumn,
+                  ),
           ),
         ),
         Expanded(
@@ -181,11 +193,21 @@ class _ExpandableTableBodyState extends State<ExpandableTableBody>
                   duration:
                       ExpandableTableData.of(context).scrollShadowDuration,
                   controller: _restColumnsController,
-                  child: ListView(
-                    controller: _restColumnsController,
-                    physics: const ClampingScrollPhysics(),
-                    children: bodyColumns,
-                  ),
+                  child: ExpandableTableData.of(context).visibleScrollbar
+                      ? ScrollConfiguration(
+                          behavior: ScrollConfiguration.of(context)
+                              .copyWith(scrollbars: false),
+                          child: ListView(
+                            controller: _restColumnsController,
+                            physics: const ClampingScrollPhysics(),
+                            children: bodyColumns,
+                          ),
+                        )
+                      : ListView(
+                          controller: _restColumnsController,
+                          physics: const ClampingScrollPhysics(),
+                          children: bodyColumns,
+                        ),
                 ),
               ),
             ),

--- a/lib/src/data.dart
+++ b/lib/src/data.dart
@@ -27,6 +27,7 @@ class ExpandableTableData extends StatefulWidget {
   final Duration scrollShadowDuration;
   final Curve scrollShadowCurve;
   final Color scrollShadowColor;
+  final bool visibleScrollbar;
 
   ExpandableTableData({
     required this.child,
@@ -39,6 +40,7 @@ class ExpandableTableData extends StatefulWidget {
     required this.scrollShadowDuration,
     required this.scrollShadowCurve,
     required this.scrollShadowColor,
+    required this.visibleScrollbar,
   });
 
   static ExpandableTableDataState of(BuildContext context) {
@@ -61,6 +63,8 @@ class ExpandableTableDataState extends State<ExpandableTableData> {
   Curve get scrollShadowCurve => widget.scrollShadowCurve;
 
   Color get scrollShadowColor => widget.scrollShadowColor;
+
+  bool get visibleScrollbar => widget.visibleScrollbar;
 
   double get cellWidth => widget.cellWidth;
 

--- a/lib/src/expandable_table.dart
+++ b/lib/src/expandable_table.dart
@@ -65,6 +65,11 @@ class ExpandableTable extends StatefulWidget {
   /// Default: [Colors.transparent]
   final Color scrollShadowColor;
 
+  /// [visibleScrollbar] determines visibility of scroolbar.
+  ///
+  /// Default: [false]
+  final bool visibleScrollbar;
+
   /// [ExpandableTable] constructor.
   /// Required:
   ///   - rows
@@ -82,6 +87,7 @@ class ExpandableTable extends StatefulWidget {
     this.scrollShadowDuration = const Duration(milliseconds: 500),
     this.scrollShadowCurve = Curves.fastOutSlowIn,
     this.scrollShadowColor = Colors.transparent,
+    this.visibleScrollbar = false,
   }) : super(key: key);
 
   @override
@@ -101,6 +107,7 @@ class _ExpandableTableState extends State<ExpandableTable> {
       scrollShadowColor: widget.scrollShadowColor,
       scrollShadowCurve: widget.scrollShadowCurve,
       scrollShadowDuration: widget.scrollShadowDuration,
+      visibleScrollbar: widget.visibleScrollbar,
       child: _Table(
         rows: widget.rows,
         header: widget.header,
@@ -215,12 +222,25 @@ class __TableState extends State<_Table> {
                     duration:
                         ExpandableTableData.of(context).scrollShadowDuration,
                     controller: _headController,
-                    child: ListView(
-                      controller: _headController,
-                      physics: ClampingScrollPhysics(),
-                      scrollDirection: Axis.horizontal,
-                      children: _buildHeaderCells(context, widget.header, null),
-                    ),
+                    child: ExpandableTableData.of(context).visibleScrollbar
+                        ? Scrollbar(
+                            child: ListView(
+                              controller: _headController,
+                              physics: ClampingScrollPhysics(),
+                              scrollDirection: Axis.horizontal,
+                              children: _buildHeaderCells(
+                                  context, widget.header, null),
+                            ),
+                            isAlwaysShown: true,
+                            controller: _headController,
+                          )
+                        : ListView(
+                            controller: _headController,
+                            physics: ClampingScrollPhysics(),
+                            scrollDirection: Axis.horizontal,
+                            children:
+                                _buildHeaderCells(context, widget.header, null),
+                          ),
                   ),
                 ),
               ],
@@ -230,6 +250,8 @@ class __TableState extends State<_Table> {
             child: ExpandableTableBody(
               scrollController: _bodyController,
               rows: widget.rows,
+              visibleScrollbar:
+                  ExpandableTableData.of(context).visibleScrollbar,
             ),
           ),
         ],


### PR DESCRIPTION
Property '**visibleScrollbar**': manages the visibility of the scrollbars, if you want to always see the two scrollbars of the table you have to set this property to _true_.